### PR TITLE
fix: add HTTPS prefix to GitHub repository URL

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -248,7 +248,7 @@ export default async function Home() {
         </div>
         <div className="flex flex-col lg:flex-row items-center justify-center gap-4 mt-12">
           <Link
-            href="github.com/logging-stuff/retroui"
+            href="https://github.com/logging-stuff/retroui"
             target="_blank"
             passHref
           >


### PR DESCRIPTION
This change ensures the link works correctly when clicked and follows standard URL formatting conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated GitHub repository link to use a fully qualified URL, ensuring correct navigation for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->