### PR TITLE
[FIX] Adjust on Dialog color-scheme for dark theme

### DIFF
--- a/components/retroui/Dialog.tsx
+++ b/components/retroui/Dialog.tsx
@@ -51,7 +51,7 @@ DialogBackdrop.displayName = "DialogBackdrop";
 
 const dialogVariants = cva(
   `fixed z-50 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 
-  flex flex-col border-2 shadow-md gap-4 overflow-y-auto bg-white
+  flex flex-col border-2 shadow-md gap-4 overflow-y-auto bg-background text-foreground
   w-full h-fit max-h-[80vh] max-w-[97%] duration-300
   data-[state=open]:animate-in 
   data-[state=open]:slide-in-from-left-1/2 
@@ -136,7 +136,7 @@ const dialogFooterVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-white text-black",
+        default: "bg-background text-foreground",
       },
       position: {
         fixed: "sticky bottom-0",

--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
     "tailwindcss": "^4.0.14",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5"
-  }
+  },
+  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,5 @@
     "tailwindcss": "^4.0.14",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5"
-  },
-  "packageManager": "pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a"
+  }
 }


### PR DESCRIPTION
This PR fix the color-scheme of Dialog component to make it consitent in dark theme.

Before:
![image](https://github.com/user-attachments/assets/accdb5d5-ef2c-4ba4-a235-e7e8055ec399)
![image](https://github.com/user-attachments/assets/8f46321c-6c9c-431a-9a80-75dbfcf4a300)
![image](https://github.com/user-attachments/assets/6601b874-cc4c-47e4-8e23-98d022406657)

After:
![image](https://github.com/user-attachments/assets/06af7d6e-5889-4d59-b9ea-1d6b90b81f43)
![image](https://github.com/user-attachments/assets/d8d5d535-d403-4431-9e46-aa3404018f04)
![image](https://github.com/user-attachments/assets/b7132536-2934-456f-badc-e0217df8428a)

For light theme it remains pretty much the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated dialog and footer colors to use theme-based background and text colors, ensuring better consistency with the application's color scheme.

- **Chores**
  - Specified the package manager and version in the configuration for improved environment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->