### PR TITLE
fix: Incorrect radio button border color under the dark theme

### DIFF
--- a/components/retroui/Radio.tsx
+++ b/components/retroui/Radio.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import * as RadioPrimitive from "@radix-ui/react-radio-group";
 import { cva, VariantProps } from "class-variance-authority";
 
-const radioVariants = cva("border-black border-2", {
+const radioVariants = cva("border-border border-2", {
   variants: {
     variant: {
       default: "",
@@ -24,9 +24,9 @@ const radioVariants = cva("border-black border-2", {
 const radioIndicatorVariants = cva("flex ", {
   variants: {
     variant: {
-      default: "bg-primary border-2 border-black",
-      outline: "border-2 border-black",
-      solid: "bg-black",
+      default: "bg-primary border-2 border-border",
+      outline: "border-2 border-border",
+      solid: "bg-border",
     },
     size: {
       sm: "h-2 w-2",


### PR DESCRIPTION
## Fix Radio Component Styles in Dark Mode

### Issue
The Radio component was using fixed black colors for borders and backgrounds, which resulted in poor visibility in dark mode and affected user experience.

### Changes
- Replace hardcoded `border-black` with theme variable `border-border`
- Update Radio indicator styles to support dark mode using theme variables

### Testing Checklist
- [x] Maintain original appearance in light mode
- [x] Borders and backgrounds properly respond to theme switching in dark mode
- [x] All size variants (sm/md/lg) display correctly
- [x] All style variants (default/outline/solid) work as expected

### Related
- Component: `components/retroui/Radio.tsx`
- Theme: Dark mode adaptation

### Visual Comparison

#### Dark Mode
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/ab403901-7e70-46d9-962f-26a7c3cac0a0) | ![image](https://github.com/user-attachments/assets/13657e6f-9f26-41e2-b00b-5450396ab485) |
| ![image](https://github.com/user-attachments/assets/317794a0-39dc-40aa-824f-d26f82b7d3c0) | ![image](https://github.com/user-attachments/assets/04dfacf7-ac2c-4b1e-ac4d-5518dafdcd1c) |
| ![image](https://github.com/user-attachments/assets/d3ff894b-98e0-47cc-a329-95f8e5115540) | ![image](https://github.com/user-attachments/assets/4e8f6fc0-6bec-42dd-bb54-4bf96f72128c) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated radio button and indicator borders to use theme-based colors instead of a fixed black, improving consistency with customizable themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->