### PR TITLE
chore(docs/breadcrumb): some links are broken

### DIFF
--- a/preview/components/breadcrumb-custom-separator.tsx
+++ b/preview/components/breadcrumb-custom-separator.tsx
@@ -12,7 +12,7 @@ export default function BreadcrumbCustomSeparator() {
           <Slash />
         </Breadcrumb.Separator>
         <Breadcrumb.Item>
-          <Breadcrumb.Link href="/components">Components</Breadcrumb.Link>
+          <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
         </Breadcrumb.Item>
         <Breadcrumb.Separator>
           <Slash />

--- a/preview/components/breadcrumb-style-default.tsx
+++ b/preview/components/breadcrumb-style-default.tsx
@@ -9,7 +9,7 @@ export default function BreadcrumbStyleDefault() {
         </Breadcrumb.Item>
         <Breadcrumb.Separator />
         <Breadcrumb.Item>
-          <Breadcrumb.Link href="/components">Components</Breadcrumb.Link>
+          <Breadcrumb.Link href="/docs/components">Components</Breadcrumb.Link>
         </Breadcrumb.Item>
         <Breadcrumb.Separator />
         <Breadcrumb.Item>


### PR DESCRIPTION
some links of BreadCrumb example were broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected breadcrumb links to point to /docs/components, ensuring accurate navigation from the “Components” breadcrumb item.
  * Applied fix across both breadcrumb variants (custom separator and default style) for consistent behavior.
  * Improves discoverability of component docs by preventing redirects to the outdated /components path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->