### PR TITLE
chore(docs/text): remove unnesessary lines

### DIFF
--- a/content/docs/components/text.mdx
+++ b/content/docs/components/text.mdx
@@ -55,7 +55,4 @@ npm install class-variance-authority
 
 ## Paragraph
 
-<hr />
-<br />
-
 <ComponentShowcase name="typography-p" />


### PR DESCRIPTION
before
<img width="721" height="660" alt="Screenshot from 2025-09-30 13-29-25" src="https://github.com/user-attachments/assets/10f542f9-f5fa-44eb-b01e-621a504c1800" />

after
<img width="721" height="660" alt="Screenshot from 2025-09-30 13-23-58" src="https://github.com/user-attachments/assets/85330248-cb98-4171-bd3f-c0250f979203" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Simplified the Paragraph section in the Text component docs by removing extra separators around the typography example, resulting in a cleaner, less cluttered layout.
  - Improved readability and visual flow in the affected section without altering behavior or logic.
  - No functional changes; content and rendering remain the same aside from reduced visual dividers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->