### PR TITLE
fix: move sidenav into layout to persist scroll position

### DIFF
--- a/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/app/(docs)/docs/[[...slug]]/page.tsx
@@ -8,7 +8,6 @@ import { Metadata } from "next";
 import { MoveUpRightIcon } from "lucide-react";
 import { generateToc } from "@/lib/toc";
 import TableOfContents from "@/components/TableOfContents";
-import SideNav from "@/components/SideNav";
 
 interface IProps {
   params: { slug: string[] };
@@ -49,12 +48,7 @@ export default async function page({ params }: IProps) {
 
   const toc = await generateToc(doc.body.raw);
   return (
-    <div className="flex lg:gap-20 items-start">
-      {/* Sidebar */}
-      <div className="hidden lg:block w-60 flex-shrink-0 sticky top-28 self-start">
-        <SideNav />
-      </div>
-
+    <>
       {/* Main Content */}
       <div className="flex-1 space-y-12 py-12 px-4 max-w-2xl mx-auto w-full">
         <div className="border-b border-black pb-6">
@@ -99,6 +93,6 @@ export default async function page({ params }: IProps) {
       <div className="hidden lg:block lg:w-60 flex-shrink-0 sticky top-36 self-start space-y-6">
         <TableOfContents toc={toc} />
       </div>
-    </div>
+    </>
   );
 }

--- a/app/(docs)/docs/layout.tsx
+++ b/app/(docs)/docs/layout.tsx
@@ -12,7 +12,15 @@ export default function ComponentLayout({
 }>) {
   return (
     <div className="relative max-w-7xl mx-auto">
-      <div className="max-lg:px-4">{children}</div>
+      <div className="max-lg:px-4">
+        <div className="flex lg:gap-20 items-start">
+          {/* Sidebar */}
+          <div className="hidden lg:block w-60 flex-shrink-0 sticky top-28 self-start">
+            <SideNav />
+          </div>
+          {children}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- kept sidenav inside docs layout so it no longer remounts on each route change  
- preserves scroll position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated documentation layout for improved responsiveness and consistency.
  * Sidebar now appears on large screens within the docs layout; hidden on smaller screens.
  * Main content and Table of Contents remain, with ToC aligned to the right on large screens.
  * Preserves outer padding and spacing for better readability.
  * Cleaner content area without redundant wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->